### PR TITLE
Fix a test in challenge 7

### DIFF
--- a/challenges/07/spec.rb
+++ b/challenges/07/spec.rb
@@ -13,7 +13,7 @@ describe "Bitmap" do
   end
 
   it "can render a column" do
-    expect(Bitmap.new([9, 32, 7, 1], 1).render).to eq <<-ASCII.strip
+    expect(Bitmap.new([9, 32, 7, 1], 4).render).to eq <<-ASCII.strip
 ....#..#
 ..#.....
 .....###


### PR DESCRIPTION
In challenge 7 in test 'can render a column' the number of rows must be 4 and not 1.
