### PR TITLE
Fix typo in sample_spec.rb file (challenge 5)

### DIFF
--- a/challenges/05/sample_spec.rb
+++ b/challenges/05/sample_spec.rb
@@ -1,5 +1,5 @@
 describe "String#anagrams" do
-  def anagrams_for(word, amongst:, are:)
+  def anagrams_for(word, amongst, are)
     expect(word.anagrams(amongst)).to match_array are
   end
 


### PR DESCRIPTION
There is a typo in definition of anagrams_for method.
I feel usage of copy-paste technique. :)
