### PR TITLE
Change task 3 CommandParser#help test to use splatting.

### DIFF
--- a/tasks/03/sample_spec.rb
+++ b/tasks/03/sample_spec.rb
@@ -47,8 +47,7 @@ describe CommandParser do
       parser.option('v', 'verbose', 'Verbose mode') { |_, _| }
       parser.option_with_parameter('r', 'require', 'require FILE in spec', 'FILE') { |_, _| }
 
-      header = parser.help.lines.first.chomp
-      options_help_messages = parser.help.lines.map(&:chomp).drop(1)
+      header, *options_help_messages = parser.help.lines.map(&:chomp)
 
       expect(header).to eq 'Usage: rspec [SPEC FILE]'
       expect(options_help_messages).to match_array([


### PR DESCRIPTION
Small refactoring of options_help_messages in the specs for task3 for #help, imo it looks more clear like this. We also had the splat lecture one week ago :P.
