### PR TITLE
Fix Version#components when receiving an argument

### DIFF
--- a/tasks/04/version.rb
+++ b/tasks/04/version.rb
@@ -26,7 +26,7 @@ class Version
     if padding_size > 0
       @components + [0] * padding_size
     elsif padding_size < 0
-      @components.take(-padding_size)
+      @components.take(positions)
     else
       @components.dup
     end


### PR DESCRIPTION
Before:
```
Version.new('1.2.3.4.5.6.7').components(2) # => [1, 2, 3, 4, 5]
```

Now:
```
Version.new('1.2.3.4.5.6.7').components(2) # => [1, 2]
```